### PR TITLE
Closing two not properly closed <span> tags in the content.php in the screen reader sections

### DIFF
--- a/content.php
+++ b/content.php
@@ -69,14 +69,14 @@
             the_content( __( '', 'simone' ) );
             echo '</div>';
             echo '<footer class="entry-footer continue-reading">';
-            echo '<a href="' . get_permalink() . '" title="' . _x('Read ', 'First part of "Read *article title* in title tag of Read more link', 'simone') . get_the_title() . '" rel="bookmark">' . __('Read <span aria-hidden="true">the article</span>', 'simone') . '<i class="fa fa-arrow-circle-o-right"></i><span class="screen-reader-text"> ' . get_the_title() . '<span></a>';
+            echo '<a href="' . get_permalink() . '" title="' . _x('Read ', 'First part of "Read *article title* in title tag of Read more link', 'simone') . get_the_title() . '" rel="bookmark">' . __('Read <span aria-hidden="true">the article</span>', 'simone') . '<i class="fa fa-arrow-circle-o-right"></i><span class="screen-reader-text"> ' . get_the_title() . '</span></a>';
             echo '</footer><!-- .entry-footer -->';
         } else { ?>
             <div class="entry-content">
                     <?php the_excerpt(); ?>
             </div><!-- .entry-content -->
             <footer class="entry-footer continue-reading">
-		<?php echo '<a href="' . get_permalink() . '" title="' . __('Continue Reading ', 'simone') . get_the_title() . '" rel="bookmark">' . __('Continue Reading', 'simone') . '<i class="fa fa-arrow-circle-o-right"></i><span class="screen-reader-text"> ' . get_the_title() . '<span></a>'; ?>
+		<?php echo '<a href="' . get_permalink() . '" title="' . __('Continue Reading ', 'simone') . get_the_title() . '" rel="bookmark">' . __('Continue Reading', 'simone') . '<i class="fa fa-arrow-circle-o-right"></i><span class="screen-reader-text"> ' . get_the_title() . '</span></a>'; ?>
             </footer><!-- .entry-footer -->
         <?php } ?>
 


### PR DESCRIPTION
Closing two not properly closed <span> tags in the content.php in the screen reader sections - in IE 8 it caused some minor issues. 
